### PR TITLE
feat(harness): Zustand session store with lifecycle actions (#4)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -88,7 +88,7 @@
       }
     },
     {
-      "files": ["scripts/**", "*.{js,cjs,mjs}"],
+      "files": ["scripts/**", "*.{js,cjs,mjs}", "**/vitest.config.ts"],
       "extends": ["plugin:@typescript-eslint/disable-type-checked"],
       "env": { "node": true }
     }

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -14,7 +14,8 @@
   },
   "devDependencies": {
     "fake-indexeddb": "^6.2.5",
-    "typescript": "*"
+    "typescript": "*",
+    "vitest": "*"
   },
   "dependencies": {
     "@potential/shared": "workspace:*",

--- a/packages/harness/src/store/session-store.test.ts
+++ b/packages/harness/src/store/session-store.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the db module before the store is imported so Dexie never touches IndexedDB.
+vi.mock("../db/life-sim-db.js", () => ({
+  db: {
+    rooms: { clear: vi.fn().mockResolvedValue(undefined) },
+    currentLife: { clear: vi.fn().mockResolvedValue(undefined) },
+  },
+}));
+
+import { useSessionStore, initialSessionState } from "./session-store.js";
+import { db } from "../db/life-sim-db.js";
+
+const mockDb = db as unknown as {
+  rooms: { clear: ReturnType<typeof vi.fn> };
+  currentLife: { clear: ReturnType<typeof vi.fn> };
+};
+
+const testPlayer = {
+  name: "Ada",
+  age: 0,
+  birthEra: "modern",
+  stats: {
+    nature: {
+      curiosity: 50,
+      resilience: 50,
+      empathy: 50,
+      ambition: 50,
+      creativity: 50,
+    },
+    nurture: {
+      curiosity: 50,
+      resilience: 50,
+      empathy: 50,
+      ambition: 50,
+      creativity: 50,
+    },
+  },
+};
+
+beforeEach(() => {
+  // Reset data fields between tests — do not pass replace=true or actions are wiped.
+  useSessionStore.setState({ ...initialSessionState });
+  // Reset mock call history.
+  mockDb.rooms.clear.mockClear();
+  mockDb.currentLife.clear.mockClear();
+});
+
+describe("useSessionStore", () => {
+  describe("initial state", () => {
+    it("starts in character-creation phase with nulled fields", () => {
+      const state = useSessionStore.getState();
+      expect(state.gamePhase).toBe("character-creation");
+      expect(state.currentRoom).toBeNull();
+      expect(state.player).toBeNull();
+      expect(state.lifeContext).toBeNull();
+      expect(state.isGenerating).toBe(false);
+    });
+  });
+
+  describe("full lifecycle", () => {
+    it("startLife → setActiveRoom → updateLifeContext → endLife resets state", async () => {
+      const { startLife, setActiveRoom, updateLifeContext, endLife } =
+        useSessionStore.getState();
+
+      // startLife transitions to playing and initialises context
+      startLife(testPlayer);
+      expect(useSessionStore.getState().gamePhase).toBe("playing");
+      expect(useSessionStore.getState().player).toEqual(testPlayer);
+      expect(useSessionStore.getState().lifeContext).toEqual({ summary: "" });
+
+      // setActiveRoom stores the active room
+      const room = {
+        id: "room_abc" as const,
+        sequenceIndex: 0,
+        previousRoomId: null,
+        nextRoomId: null,
+        label: "Birth room",
+        description: "A warm room.",
+        objects: new Map(),
+        summary: null,
+        era: "modern" as const,
+        createdAt: Date.now(),
+        exitedAt: null,
+      };
+      setActiveRoom(room);
+      expect(useSessionStore.getState().currentRoom).toEqual(room);
+
+      // updateLifeContext stores the compression output
+      updateLifeContext({ summary: "Born in a warm room." });
+      expect(useSessionStore.getState().lifeContext).toEqual({
+        summary: "Born in a warm room.",
+      });
+
+      // endLife transitions to dead and clears everything
+      await endLife();
+      const after = useSessionStore.getState();
+      expect(after.gamePhase).toBe("dead");
+      expect(after.currentRoom).toBeNull();
+      expect(after.player).toBeNull();
+      expect(after.lifeContext).toBeNull();
+      expect(after.isGenerating).toBe(false);
+    });
+  });
+
+  describe("endLife()", () => {
+    it("clears both Dexie tables", async () => {
+      useSessionStore.getState().startLife(testPlayer);
+      await useSessionStore.getState().endLife();
+
+      expect(mockDb.rooms.clear).toHaveBeenCalledOnce();
+      expect(mockDb.currentLife.clear).toHaveBeenCalledOnce();
+    });
+
+    it("can be called from any phase without throwing", async () => {
+      // character-creation phase
+      await expect(
+        useSessionStore.getState().endLife()
+      ).resolves.toBeUndefined();
+
+      // dead phase
+      await expect(
+        useSessionStore.getState().endLife()
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("invalid transitions", () => {
+    it("setActiveRoom before startLife throws", () => {
+      const room = {
+        id: "room_xyz" as const,
+        sequenceIndex: 0,
+        previousRoomId: null,
+        nextRoomId: null,
+        label: "Test room",
+        description: "A test.",
+        objects: new Map(),
+        summary: null,
+        era: "modern" as const,
+        createdAt: Date.now(),
+        exitedAt: null,
+      };
+      expect(() => {
+        useSessionStore.getState().setActiveRoom(room);
+      }).toThrow('setActiveRoom called in invalid phase: "character-creation"');
+    });
+
+    it("setActiveRoom after endLife throws", async () => {
+      useSessionStore.getState().startLife(testPlayer);
+      await useSessionStore.getState().endLife();
+
+      const room = {
+        id: "room_xyz" as const,
+        sequenceIndex: 0,
+        previousRoomId: null,
+        nextRoomId: null,
+        label: "Test room",
+        description: "A test.",
+        objects: new Map(),
+        summary: null,
+        era: "modern" as const,
+        createdAt: Date.now(),
+        exitedAt: null,
+      };
+      expect(() => {
+        useSessionStore.getState().setActiveRoom(room);
+      }).toThrow('setActiveRoom called in invalid phase: "dead"');
+    });
+  });
+});

--- a/packages/harness/src/store/session-store.ts
+++ b/packages/harness/src/store/session-store.ts
@@ -1,20 +1,62 @@
 import { create } from "zustand";
-import type { Room, PlayerIdentity } from "@potential/shared";
+import type { Room, PlayerIdentity, LifeContext } from "@potential/shared";
+import { db } from "../db/life-sim-db.js";
+
+export type GamePhase = "character-creation" | "playing" | "dead";
 
 interface SessionState {
+  gamePhase: GamePhase;
   currentRoom: Room | null;
   player: PlayerIdentity | null;
+  lifeContext: LifeContext | null;
   isGenerating: boolean;
-  setCurrentRoom: (room: Room) => void;
-  setPlayer: (player: PlayerIdentity) => void;
-  setGenerating: (v: boolean) => void;
+  startLife: (player: PlayerIdentity) => void;
+  setActiveRoom: (room: Room) => void;
+  updateLifeContext: (ctx: LifeContext) => void;
+  endLife: () => Promise<void>;
 }
 
-export const useSessionStore = create<SessionState>((set) => ({
+export const initialSessionState = {
+  gamePhase: "character-creation" as GamePhase,
   currentRoom: null,
   player: null,
+  lifeContext: null,
   isGenerating: false,
-  setCurrentRoom: (room) => { set({ currentRoom: room }); },
-  setPlayer: (player) => { set({ player }); },
-  setGenerating: (isGenerating) => { set({ isGenerating }); },
+} as const;
+
+export const useSessionStore = create<SessionState>((set, get) => ({
+  ...initialSessionState,
+
+  startLife: (player) => {
+    set({
+      player,
+      lifeContext: { summary: "" },
+      gamePhase: "playing",
+    });
+  },
+
+  setActiveRoom: (room) => {
+    const { gamePhase } = get();
+    if (gamePhase !== "playing") {
+      throw new Error(
+        `setActiveRoom called in invalid phase: "${gamePhase}". Call startLife() first.`
+      );
+    }
+    set({ currentRoom: room });
+  },
+
+  updateLifeContext: (ctx) => {
+    set({ lifeContext: ctx });
+  },
+
+  endLife: async () => {
+    set({
+      gamePhase: "dead",
+      currentRoom: null,
+      player: null,
+      lifeContext: null,
+      isGenerating: false,
+    });
+    await Promise.all([db.rooms.clear(), db.currentLife.clear()]);
+  },
 }));

--- a/packages/harness/vitest.config.ts
+++ b/packages/harness/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,4 +4,5 @@
 export * from "./types/world-object.js";
 export * from "./types/room.js";
 export * from "./types/player.js";
+export * from "./types/life-context.js";
 export * from "./schemas/index.js";

--- a/packages/shared/src/types/life-context.ts
+++ b/packages/shared/src/types/life-context.ts
@@ -1,0 +1,8 @@
+/**
+ * LifeContext — accumulated narrative context for the current life.
+ * Stubbed in Phase 1. Fields expanded in Phase 2 when compress_player_memory() is wired.
+ */
+export interface LifeContext {
+  /** Latest compression output string from compress_player_memory(). */
+  summary: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       typescript:
         specifier: '*'
         version: 5.9.3
+      vitest:
+        specifier: '*'
+        version: 1.6.1(@types/node@18.19.130)
 
   packages/renderer:
     dependencies:


### PR DESCRIPTION
Closes #4

## Summary

- Implements `useSessionStore` per AC: `gamePhase`, `lifeContext`, `currentRoom`, `player`, `isGenerating`
- Lifecycle actions: `startLife` / `setActiveRoom` / `updateLifeContext` / `endLife`
- `endLife` transitions to `dead`, resets all in-memory state, wipes Dexie `rooms` + `currentLife` tables
- `setActiveRoom` throws if called outside `playing` phase
- 6 unit tests: full lifecycle, Dexie table clearing, invalid transition guards

## Also included

- `LifeContext` stub type added to `@potential/shared` (fields expanded in Phase 2 when `compress_player_memory()` is wired)
- `CurrentLife` type + `currentLife` table added to `LifeSimDb` (needed for `endLife` wipe)
- `vitest.config.ts` + `vitest` devDep added to `@potential/harness`
- Root `.eslintrc.json` override: disable type-checked rules for `vitest.config.ts` files (they're outside `rootDir` so can't be in the build tsconfig)

## Test plan

- [ ] `pnpm turbo run lint type-check test` — all 19 tasks pass locally
- [ ] CI passes on this PR
- [ ] Review lifecycle action semantics match AC

https://claude.ai/code/session_01NEmx4Vy9BYCana2jqkBHFJ