### PR TITLE
feat(harness): compression trigger on room exit (#5)

### DIFF
--- a/packages/harness/src/__tests__/room-exit.test.ts
+++ b/packages/harness/src/__tests__/room-exit.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Room, RoomId } from "@potential/shared";
+
+// Mock the db before any module that imports it is loaded.
+vi.mock("../db/life-sim-db.js", () => ({
+  db: {
+    rooms: { clear: vi.fn().mockResolvedValue(undefined) },
+    currentLife: { clear: vi.fn().mockResolvedValue(undefined) },
+  },
+}));
+
+// Mock insertRoom so tests never touch real IndexedDB.
+vi.mock("../db/room-store.js", () => ({
+  insertRoom: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { onRoomExit } from "../room-exit.js";
+import { useSessionStore, initialSessionState } from "../store/session-store.js";
+import { insertRoom } from "../db/room-store.js";
+import { LinkedListError } from "../db/errors.js";
+
+const mockInsertRoom = vi.mocked(insertRoom);
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeRoom(overrides: Partial<Room> = {}): Room {
+  return {
+    id: `room_${crypto.randomUUID()}` as RoomId,
+    sequenceIndex: 0,
+    previousRoomId: null,
+    nextRoomId: null,
+    label: "Test Room",
+    description: "A test room.",
+    objects: new Map(),
+    summary: null,
+    era: "modern",
+    createdAt: Date.now(),
+    exitedAt: null,
+    ...overrides,
+  };
+}
+
+const stubCompressRoom = vi.fn().mockResolvedValue("[compression stub]");
+
+beforeEach(() => {
+  useSessionStore.setState({ ...initialSessionState });
+  mockInsertRoom.mockClear();
+  mockInsertRoom.mockResolvedValue(undefined);
+  stubCompressRoom.mockClear();
+  stubCompressRoom.mockResolvedValue("[compression stub]");
+});
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe("onRoomExit — happy path", () => {
+  it("inserts the room into Dexie with a non-null exitedAt", async () => {
+    await onRoomExit(makeRoom(), stubCompressRoom);
+
+    expect(mockInsertRoom).toHaveBeenCalledOnce();
+    expect(mockInsertRoom).toHaveBeenCalledWith(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- expect.objectContaining returns AsymmetricMatcher typed as any in Vitest
+      expect.objectContaining({ exitedAt: expect.any(Number) }),
+    );
+  });
+
+  it("inserts the room into Dexie with the compression summary set", async () => {
+    await onRoomExit(makeRoom(), stubCompressRoom);
+
+    expect(mockInsertRoom).toHaveBeenCalledWith(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- expect.objectContaining returns AsymmetricMatcher typed as any in Vitest
+      expect.objectContaining({ summary: "[compression stub]" }),
+    );
+  });
+
+  it("updates lifeContext in the session store with the compression summary", async () => {
+    await onRoomExit(makeRoom(), stubCompressRoom);
+
+    expect(useSessionStore.getState().lifeContext?.summary).toBe("[compression stub]");
+  });
+
+  it("passes the room with exitedAt stamped to compressRoom", async () => {
+    await onRoomExit(makeRoom({ exitedAt: null }), stubCompressRoom);
+
+    expect(stubCompressRoom).toHaveBeenCalledWith(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- expect.objectContaining returns AsymmetricMatcher typed as any in Vitest
+      expect.objectContaining({ exitedAt: expect.any(Number) }),
+      expect.anything(),
+    );
+  });
+
+  it("passes the current lifeContext from the session store to compressRoom", async () => {
+    useSessionStore.setState({ lifeContext: { summary: "prior context" } });
+
+    await onRoomExit(makeRoom(), stubCompressRoom);
+
+    expect(stubCompressRoom).toHaveBeenCalledWith(
+      expect.anything(),
+      { summary: "prior context" },
+    );
+  });
+
+  it("falls back to empty summary when lifeContext is null", async () => {
+    // Initial state has lifeContext: null.
+    await onRoomExit(makeRoom(), stubCompressRoom);
+
+    expect(stubCompressRoom).toHaveBeenCalledWith(
+      expect.anything(),
+      { summary: "" },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pipeline step ordering
+// ---------------------------------------------------------------------------
+
+describe("onRoomExit — pipeline ordering", () => {
+  it("calls compressRoom before insertRoom", async () => {
+    const callOrder: string[] = [];
+
+    const orderedCompress = vi.fn().mockImplementation(() => {
+      callOrder.push("compressRoom");
+      return Promise.resolve("[stub]");
+    });
+    mockInsertRoom.mockImplementation(() => {
+      callOrder.push("insertRoom");
+      return Promise.resolve();
+    });
+
+    await onRoomExit(makeRoom(), orderedCompress);
+
+    expect(callOrder).toEqual(["compressRoom", "insertRoom"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compression failure
+// ---------------------------------------------------------------------------
+
+describe("onRoomExit — compression failure", () => {
+  it("propagates the error from compressRoom", async () => {
+    const failingCompress = vi.fn().mockRejectedValue(new Error("LLM unavailable"));
+
+    await expect(onRoomExit(makeRoom(), failingCompress)).rejects.toThrow("LLM unavailable");
+  });
+
+  it("does not write to Dexie when compressRoom throws", async () => {
+    const failingCompress = vi.fn().mockRejectedValue(new Error("LLM unavailable"));
+
+    await expect(onRoomExit(makeRoom(), failingCompress)).rejects.toThrow();
+    expect(mockInsertRoom).not.toHaveBeenCalled();
+  });
+
+  it("does not update lifeContext when compressRoom throws", async () => {
+    useSessionStore.setState({ lifeContext: { summary: "unchanged" } });
+    const failingCompress = vi.fn().mockRejectedValue(new Error("LLM unavailable"));
+
+    await expect(onRoomExit(makeRoom(), failingCompress)).rejects.toThrow();
+    expect(useSessionStore.getState().lifeContext?.summary).toBe("unchanged");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// insertRoom failure
+// ---------------------------------------------------------------------------
+
+describe("onRoomExit — insertRoom failure", () => {
+  it("propagates the error from insertRoom", async () => {
+    mockInsertRoom.mockRejectedValueOnce(new LinkedListError("list invariant violated"));
+
+    await expect(onRoomExit(makeRoom(), stubCompressRoom)).rejects.toThrow(LinkedListError);
+  });
+
+  it("does not update lifeContext when insertRoom throws", async () => {
+    useSessionStore.setState({ lifeContext: { summary: "unchanged" } });
+    mockInsertRoom.mockRejectedValueOnce(new LinkedListError("list invariant violated"));
+
+    await expect(onRoomExit(makeRoom(), stubCompressRoom)).rejects.toThrow();
+    expect(useSessionStore.getState().lifeContext?.summary).toBe("unchanged");
+  });
+});

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -3,3 +3,4 @@
 
 export * from "./db/index.js";
 export * from "./store/index.js";
+export * from "./room-exit.js";

--- a/packages/harness/src/room-exit.ts
+++ b/packages/harness/src/room-exit.ts
@@ -1,0 +1,53 @@
+import type { Room, LifeContext } from "@potential/shared";
+import { insertRoom } from "./db/room-store.js";
+import { useSessionStore } from "./store/session-store.js";
+
+/**
+ * CompressRoomFn — injected compression function.
+ *
+ * Phase 1 stub: returns "[compression stub]" synchronously (no LLM call).
+ * Phase 2 (issue #10): replaced by compress_player_memory() via Haiku.
+ *
+ * The harness calls this; the agent package provides the real implementation.
+ * Never import compress_player_memory from @potential/agent here.
+ */
+export type CompressRoomFn = (room: Room, lifeContext: LifeContext) => Promise<string>;
+
+/**
+ * onRoomExit — the single entry point for all room transitions.
+ *
+ * Executes the 6-step pipeline in strict sequential order:
+ *   1. Stamp exitedAt on the room (in memory, before Dexie write)
+ *   2. Call injected compressRoom(room, lifeContext) → summary string
+ *   3. Attach summary to the room
+ *   4. insertRoom(room) — persist the completed room to Dexie
+ *   5. updateLifeContext({ summary }) — update Zustand session state
+ *   6. Return — signals ready for N+1 candidate selection
+ *
+ * Error semantics:
+ *   - Any step failure propagates immediately.
+ *   - Dexie is never written if compression fails (step 2 throws → step 4 never runs).
+ *   - lifeContext is never updated if insertRoom fails (step 4 throws → step 5 never runs).
+ *
+ * @param room - The active room being exited. Expected to have exitedAt: null.
+ * @param compressRoom - Injected compression fn. Never import from @potential/agent.
+ */
+export async function onRoomExit(room: Room, compressRoom: CompressRoomFn): Promise<void> {
+  // Step 1: Stamp exit time.
+  const exitedRoom: Room = { ...room, exitedAt: Date.now() };
+
+  // Step 2: Compress.
+  const { lifeContext } = useSessionStore.getState();
+  const summary = await compressRoom(exitedRoom, lifeContext ?? { summary: "" });
+
+  // Step 3: Attach summary.
+  const completedRoom: Room = { ...exitedRoom, summary };
+
+  // Step 4: Persist to Dexie.
+  await insertRoom(completedRoom);
+
+  // Step 5: Update Zustand with latest compression output.
+  useSessionStore.getState().updateLifeContext({ summary });
+
+  // Step 6: Return — N+1 candidate selection may begin.
+}


### PR DESCRIPTION
Closes #5

## Summary

- `onRoomExit(room, compressRoom)` — single entry point for all room transitions
- Strict 6-step pipeline: stamp `exitedAt` → compress → attach summary → `insertRoom` → `updateLifeContext` → return
- `compressRoom` is an injected dependency — harness/agent boundary fully preserved
- Phase 1 stub: caller passes `() => Promise.resolve("[compression stub]")`, no LLM involved
- Error propagation: Dexie never written if compression fails; `lifeContext` never updated if `insertRoom` fails
- `onRoomExit` and `CompressRoomFn` exported from `@potential/harness`

## Test plan

- [ ] `pnpm turbo run lint type-check test` — 19/19 tasks, 46/46 tests pass
- [ ] CI passes on this PR
- [ ] Review pipeline step semantics match AC in #5

## Tests (12)

**Happy path:** room inserted with non-null `exitedAt`; room inserted with summary set; `lifeContext` updated in store; `compressRoom` receives `exitedAt`-stamped room; lifeContext passed through; null lifeContext falls back to `{ summary: "" }`

**Pipeline ordering:** `compressRoom` called before `insertRoom` (verified via call order log)

**Compression failure:** error propagates; `insertRoom` not called; `lifeContext` unchanged

**insertRoom failure:** error propagates; `lifeContext` unchanged

https://claude.ai/code/session_01SxkwA9PEXTvJ53VYsYciaE